### PR TITLE
Fix Position of added FrontMatter on save, when there is none.

### DIFF
--- a/src/markdownDocument.ts
+++ b/src/markdownDocument.ts
@@ -154,8 +154,8 @@ modified: '${new Date().toISOString()}'
     const newMatter = `---\n${yaml.stringify(matterData)}---`;
 
     if (oldMatterNode === undefined) {
-      const snippet = new SnippetString(`${newMatter}\n`);
-      editor.insertSnippet(snippet);
+      const snippet = new SnippetString(`${newMatter}\n\n`);
+      editor.insertSnippet(snippet, new Position(0, 0));
     } else {
       const firstMatterPosition = editor.document.positionAt(oldMatterNode.range[0]);
       const secondMatterPosition = editor.document.positionAt(oldMatterNode.range[1]);


### PR DESCRIPTION
When there is no FrontMatter in an md-file, and you save it, the FrontMatter will be added at the cursor position.

`insertSnippet` has an optional `Position` parameter where to add the Snippet, so I set it to the beginning of the file. I've also added an additional blank line after the FrontMatter.