### PR TITLE
Add functionality to add FrontMatter to existing file, when there is none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "md-tags" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## v0.2.2
+
+- add function to add FrontMatter to file when there is none 
+
 ## v0.2.1
 
 - create note now create in workspace

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+:warning: This repo is unmaintained it's only used to file pull request :warning:
+
 # Notable for VScode
 
 VSCode plugin to take Markdown notes following [Notable](https://notable.app/) format.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-:warning: This repo is unmaintained it's only used to file pull request :warning:
-
 # Notable for VScode
 
 VSCode plugin to take Markdown notes following [Notable](https://notable.app/) format.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
       },
       {
         "when": "resourceLangId == md",
+        "command": "notable.addFrontmatter",
+        "title": "Notable: Add Frontmatter"
+      },
+      {
+        "when": "resourceLangId == md",
         "command": "notable.safeDeleteNote",
         "title": "Notable: Safe delete a new note"
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Notable",
   "description": "Create, edit and search Markdown notes from Notable.",
   "icon": "images/logo.png",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "vscode": "^1.46.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,10 @@ async function addFrontmatter() {
     return;
   }
 
-  new MarkdownDocument(editor.document).createFrontMatter();
+  // get creation time of file from FileSystem.stat
+  // some/most fs do not store the creation time, so this date will potentially be the last modified date
+  const stats = await workspace.fs.stat(editor.document.uri)
+  new MarkdownDocument(editor.document).createFrontMatter(new Date(stats.ctime));
 }
 
 async function searchNote() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,17 @@ function createNote() {
   return MarkdownDocument.create();
 }
 
+async function addFrontmatter() {
+  const editor = window.activeTextEditor;
+
+  if (editor === undefined) {
+    window.showErrorMessage("Please open an editor");
+    return;
+  }
+
+  new MarkdownDocument(editor.document).createFrontMatter();
+}
+
 async function searchNote() {
   const queryStr = await window.showInputBox({
     prompt: "What do you search",
@@ -107,6 +118,7 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(
     commands.registerCommand("notable.createNote", createNote),
     commands.registerCommand("notable.addTagNote", addTagNote),
+    commands.registerCommand("notable.addFrontmatter", addFrontmatter),
     commands.registerCommand("notable.safeDeleteNote", deleteNote),
     commands.registerCommand("notable.searchNote", searchNote)
   );

--- a/src/markdownDocument.ts
+++ b/src/markdownDocument.ts
@@ -4,7 +4,7 @@ import {Position, Range, SnippetString, TextDocument, Uri, window, workspace, Wo
 import {onSaveDenyListFile, onSaveRenameFile, onSaveUpdateFrontMatter} from "./config";
 const parse = require("markdown-to-ast").parse;
 import yaml = require("yaml");
-const sanitize = require("sanitize-filename");
+import sanitize = require("sanitize-filename");
 
 export class MarkdownDocument {
   private frontMatterData: any | undefined;
@@ -68,6 +68,19 @@ modified: '${new Date().toISOString()}'
       data.deleted = true;
     }
     this.updateFrontMatter(data);
+  }
+
+  createFrontMatter() {
+    const data = this.frontMatterData
+
+    if (Object.entries(data).length ===  0) {
+      const title = this.getCurrentTitle();
+      data.title = title !== undefined ? title : 'Undefined'
+      data.tags = [];
+      data.created= new Date().toISOString();
+      data.modified= new Date().toISOString();
+      this.updateFrontMatter(data);
+    }
   }
 
   get isOnSaveDenyList() {

--- a/src/markdownDocument.ts
+++ b/src/markdownDocument.ts
@@ -73,14 +73,14 @@ modified: '${new Date().toISOString()}'
     this.updateFrontMatter(data);
   }
 
-  createFrontMatter() {
+  createFrontMatter(ctime: Date) {
     const data = this.frontMatterData;
 
     if (Object.entries(data).length ===  0) {
       const title = this.getCurrentTitle();
       data.title = title !== undefined ? title : 'Undefined';
       data.tags = [];
-      data.created= new Date().toISOString();
+      data.created= ctime;
       data.modified= new Date().toISOString();
       this.updateFrontMatter(data);
     } else {

--- a/src/markdownDocument.ts
+++ b/src/markdownDocument.ts
@@ -74,15 +74,17 @@ modified: '${new Date().toISOString()}'
   }
 
   createFrontMatter() {
-    const data = this.frontMatterData
+    const data = this.frontMatterData;
 
     if (Object.entries(data).length ===  0) {
       const title = this.getCurrentTitle();
-      data.title = title !== undefined ? title : 'Undefined'
+      data.title = title !== undefined ? title : 'Undefined';
       data.tags = [];
       data.created= new Date().toISOString();
       data.modified= new Date().toISOString();
       this.updateFrontMatter(data);
+    } else {
+      window.showInformationMessage("Nothing to do. The file already has FrontMatter.");
     }
   }
 


### PR DESCRIPTION
Due to this Bug #5 and for the reason, that I have md-files without FrontMatter I've added a function to add FrontMatter to the file.

The FrontMatter will only be added it there is no FrontMatter in the file. 

As created timestamp the current time is used, I know that's not correct, but I didn't find a way to obtain the file creation date in VS Code.

As an additional option it could be possible to merge the existing FrontMatter with the Notable FrontMatter, but that isn't implemented yet.

The fix #6 should be merged first.