### PR TITLE
Fix vulnerabilities

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
         "@typescript-eslint"
     ],
     "rules": {
-        "@typescript-eslint/class-name-casing": "warn",
+        "@typescript-eslint/naming-convention" : "warn",
         "@typescript-eslint/semi": "warn",
         "curly": "warn",
         "eqeqeq": "warn",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+:warning: This repo is unmaintained it's only used to file pull request :warning:
+
 # Notable for VScode
 
 VSCode plugin to take Markdown notes following [Notable](https://notable.app/) format.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-:warning: This repo is unmaintained it's only used to file pull request :warning:
-
 # Notable for VScode
 
 VSCode plugin to take Markdown notes following [Notable](https://notable.app/) format.

--- a/package.json
+++ b/package.json
@@ -85,17 +85,17 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.11.0",
     "@types/vscode": "^1.46.0",
-    "@typescript-eslint/eslint-plugin": "^2.30.0",
-    "@typescript-eslint/parser": "^2.30.0",
-    "eslint": "^6.8.0",
+    "@typescript-eslint/eslint-plugin": "^5.10.2",
+    "@typescript-eslint/parser": "^5.10.2",
+    "eslint": "^8.8.0",
     "glob": "^7.1.6",
-    "mocha": "^7.1.2",
+    "mocha": "^9.2.0",
     "typescript": "^4.3.5",
     "vscode-test": "^1.3.0"
   },
   "dependencies": {
+    "@textlint/markdown-to-ast": "^12.1.0",
     "gray-matter": "^4.0.2",
-    "markdown-to-ast": "^6.0.3",
     "sanitize-filename": "^1.6.3",
     "yaml": "^1.10.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ async function addFrontmatter() {
 
   // get creation time of file from FileSystem.stat
   // some/most fs do not store the creation time, so this date will potentially be the last modified date
-  const stats = await workspace.fs.stat(editor.document.uri)
+  const stats = await workspace.fs.stat(editor.document.uri);
   new MarkdownDocument(editor.document).createFrontMatter(new Date(stats.ctime));
 }
 

--- a/src/markdownDocument.ts
+++ b/src/markdownDocument.ts
@@ -2,10 +2,10 @@ import matter = require("gray-matter");
 import { basename, dirname, extname, join } from "path";
 import { Position, Range, SnippetString, TextDocument, Uri, window, workspace, WorkspaceEdit } from "vscode";
 import { onSaveDenyListFile, onSaveRenameFile, onSaveUpdateFrontMatter } from "./config";
-const parse = require("markdown-to-ast").parse;
 import yaml = require("yaml");
 import path = require("path");
 
+const parse = require("@textlint/markdown-to-ast").parse;
 const sanitize = require("sanitize-filename");
 
 export class MarkdownDocument {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import {promises} from "fs";
 import {basename, extname, join} from "path";
 import {Progress, ProgressLocation, QuickPickItem, window, workspace} from "vscode";
 import matter = require("gray-matter");
-const parse = require("markdown-to-ast").parse;
+const parse = require("@textlint/markdown-to-ast").parse;
 
 const MD_EXTENSIONS = [".md", ".markdown"];
 


### PR DESCRIPTION
PR to fix #8 

I didn't commit `package-lock.json` because merging is always a mess with different npm version.
I'll can add it if you wish.

`markdown-to-ast` has been replaced by `@textlint/markdown-to-ast` see https://github.com/textlint/markdown-to-ast/
`@typescript-eslint/class-name-casing` is superseded by `@typescript-eslint/naming-convention` see https://github.com/typescript-eslint/typescript-eslint/issues/2244


Also fix a linting error.